### PR TITLE
Add profile option to require password confirmation.

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -149,6 +149,10 @@
             			<input class="standard" id="passwordSuffix"/>
                     </div>
 
+                    <div class="row">
+                            <input type="checkbox" id="passwordConfirm"/>
+                            <label for="passwordConfirm" class="checkbox">Require confirmation of password.</label>
+                    </div>
 
                     <div class="row">
                         <a class="secondColumn" href="#" onClick="cloneProfile();">Clone this profile.</a>

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -77,6 +77,7 @@ function setCurrentProfile(profile) {
     $("#modifier").val(profile.modifier);
     $("#passwordPrefix").val(profile.passwordPrefix);
     $("#passwordSuffix").val(profile.passwordSuffix);
+    $("#passwordConfirm").attr('checked', profile.passwordConfirm);
     
     $("#charset").empty();
     
@@ -130,19 +131,20 @@ function highlightProfile(){
 }
 
 function saveProfile() {
-    currentProfile.title = $("#profileNameTB").val();
-    currentProfile.url_protocol = $("#protocolCB").attr('checked');
-    currentProfile.url_subdomain = $("#subdomainCB").attr('checked');
-    currentProfile.url_domain = $("#domainCB").attr('checked');
-    currentProfile.url_path = $("#pathCB").attr('checked');
-    currentProfile.whereToUseL33t = $("#whereLeetLB").val();
-    currentProfile.l33tLevel      = $("#leetLevelLB").val();
-    currentProfile.hashAlgorithm  = $("#hashAlgorithmLB").val();
-    currentProfile.passwordLength = $("#passwdLength").val();
-    currentProfile.username       = $("#usernameTB").val();
-    currentProfile.modifier       = $("#modifier").val();
-    currentProfile.passwordPrefix = $("#passwordPrefix").val();
-    currentProfile.passwordSuffix = $("#passwordSuffix").val();
+    currentProfile.title           = $("#profileNameTB").val();
+    currentProfile.url_protocol    = $("#protocolCB").attr('checked');
+    currentProfile.url_subdomain   = $("#subdomainCB").attr('checked');
+    currentProfile.url_domain      = $("#domainCB").attr('checked');
+    currentProfile.url_path        = $("#pathCB").attr('checked');
+    currentProfile.whereToUseL33t  = $("#whereLeetLB").val();
+    currentProfile.l33tLevel       = $("#leetLevelLB").val();
+    currentProfile.hashAlgorithm   = $("#hashAlgorithmLB").val();
+    currentProfile.passwordLength  = $("#passwdLength").val();
+    currentProfile.username        = $("#usernameTB").val();
+    currentProfile.modifier        = $("#modifier").val();
+    currentProfile.passwordPrefix  = $("#passwordPrefix").val();
+    currentProfile.passwordSuffix  = $("#passwordSuffix").val();
+    currentProfile.passwordConfirm = $("#passwordConfirm").attr('checked');
     
     if ($("#charset").val() == "Custom charset"){
         currentProfile.selectedCharset= $("#customCharset").val();

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -25,7 +25,7 @@ function updateFields() {
     } else if ( ! matchesHash(password) ) {
         $("#generated").val("Master password mismatch");
         setPasswordColors("#FFFFFF", "#FF7272")
-    } else if (!Settings.keepMasterPasswordHash() && password != confirmation) {
+    } else if (!Settings.keepMasterPasswordHash() && profile.passwordConfirm && password != confirmation) {
         $("#generated").val("Password wrong");
         setPasswordColors("#FFFFFF", "#FF7272")
     } else {        
@@ -36,7 +36,7 @@ function updateFields() {
         }
         setPasswordColors("#000000", "#FFFFFF")
     }
-    if (Settings.keepMasterPasswordHash()) {
+    if (Settings.keepMasterPasswordHash() || !profile.passwordConfirm) {
       $("#confirmation_row").css('display', 'none');
     } else {
       $("#confirmation_row").css('display', 'block');

--- a/javascript/profile.js
+++ b/javascript/profile.js
@@ -16,6 +16,7 @@ function Profile() {
     this.selectedCharset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`~!@#$%^&*()_-+={}|[]\\:\";'<>?,./";
     this.passwordPrefix = "";
     this.passwordSuffix = "";
+    this.passwordConfirm = true;
     this.whereToUseL33t = "off";
     this.l33tLevel = 0;
 }


### PR DESCRIPTION
I missed an obscure feature of my Firefox PasswordMaker extension -- to eliminate the need to enter my master password twice.

This commit adds that option, allowing the user to disable the Password Confirmation requirement.

I hope you find my contribution worthy of inclusion. Thanks.

-Tim
