### PR TITLE
Auto select profile when used text matches profile title

### DIFF
--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -95,6 +95,11 @@ function init(url) {
         var options = "";
         for (var i in profiles) {
             var profile = profiles[i];
+            // Based on profile settings, determine what the used
+            // text would be and select on exact profile match
+            if (profile.getUrl(url) == profile.title) {
+                Settings.setActiveProfileId(profile.id);
+            }
             options += "<option value='"+profile.id+"'";
             if (profile.id == Settings.getActiveProfileId()){
                 options += " selected='true' ";


### PR DESCRIPTION
The use case is a profile name (e.g., google.com) will automatically
be selected when the profile is set to match domain and is used at a
google.com site.

If there is no match, the original behaviour of selecting the previous
profile is unchanged.
