### PR TITLE
Fix an edge case that causes the salt to be lost

### DIFF
--- a/javascript/settings.js
+++ b/javascript/settings.js
@@ -218,9 +218,15 @@ Settings.saveProfiles = function() {
     localStorage["profiles"] = stringified;
     if (Settings.shouldSyncProfiles() &&
         (!Settings.syncDataAvailable || Settings.syncPasswordOk)) {
-        Settings.saveSyncedProfiles(Settings.encrypt(
+        encrypted = Settings.encrypt(
             stringified, 
-            Settings.syncProfilesPassword()).value);
+            Settings.syncProfilesPassword()).value;
+        parsed = JSON.parse(encrypted);
+        if (parsed.salt == undefined) {
+          parsed.salt = JSON.parse(localStorage["synced_profiles"]).salt;
+          encrypted = JSON.stringify(parsed);
+        }
+        Settings.saveSyncedProfiles(encrypted);
     }
 }
 


### PR DESCRIPTION
When synced profiles are encrypted for the 2nd time, the key is used
instead of the password, and no salt is saved. This causes the salt
value to be lost, which in turn causes new clients not to be able to
decrypt the synced data.

Ensure that the salt value is always stored.
