### PR TITLE
Press enter fills page password field when keepMasterPasswordHash is tru...

### DIFF
--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -257,8 +257,16 @@ $(function() {
   // Tab navigation workaround, see http://code.google.com/p/chromium/issues/detail?id=122352
   // Use Enter instead of Tab
   $("#password").keypress(function(event) {
-    if (event.keyCode == 13) {
+    if (event.keyCode == 13 && !Settings.keepMasterPasswordHash()) {
       $("#confirmation").focus();
     }
+    else if (event.keyCode == 13) {
+      chrome.tabs.sendRequest(currentTab, {hasPasswordField: true}, function(response) {
+        if (response.hasField) {
+          fillPassword();
+        }
+      });
+    }
+    
   });
 });


### PR DESCRIPTION
Pressing enter should fill the password field of the page, but if keepMasterPasswordHash is true, it attempts to focus on the hidden 'confirmation' field in the popup and does not fill the password on the page. This is a fix for that problem.
