### PR TITLE
Store full URL, not only required text for pwd

### DIFF
--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -113,10 +113,10 @@ function updateURL(url) {
         profileId = getAutoProfileIdForUrl(url);        
     }
     var profile = Settings.getProfile(profileId);
-    // Store profile matched url to ALT attribute
-    $("#usedtext").attr('alt', profile.getUrl(url));
+    // Store url in ALT attribute
+    $("#usedtext").attr('alt', url);
     // Store either matched url or, if set, use profiles own "use text"
-    $("#usedtext").val(((profile.getText()) ? profile.getText() : $("#usedtext").attr('alt')));
+    $("#usedtext").val(((profile.getText()) ? profile.getText() : profile.getUrl(url)));
 }
 
 function onProfileChanged() {


### PR DESCRIPTION
The code uses the "UsedText" field to store the URL, but it stored only
the part of the URL it was using for password generation.

So for example
- I visit: http://example.com/index.html
- And have a profile with regex /https?://([^/]+.)_example.com/._/
- But the profile only uses "example.com" for the password generation
- It stores "example.com" as the url matched
- When trying to find the profile again, "example.com" isn't enough to
  match the regex
- Unable to find the matching profile, no password generated

Now with the full URL stored it should find the correct profile
