### PR TITLE
Fix blank password error

### DIFF
--- a/javascript/settings.js
+++ b/javascript/settings.js
@@ -297,7 +297,7 @@ Settings.getPassword = function(callback) {
         chrome.extension.sendRequest({getPassword: true}, function(response) {
             if (response.password != null && response.password.length > 0) {
                 callback(response.password);
-            } else if (localStorage["password_crypt"]) {
+            } else if (!localStorage["password_crypt"]===undefined) {
                 Settings.password = byteArrayToString(rijndaelDecrypt(hexToByteArray(localStorage["password_crypt"]), hexToByteArray(localStorage["password_key"]), "CBC"));
                 callback(Settings.password)
             } else if (localStorage["password"]) {


### PR DESCRIPTION
If I blank the password in the popup, then close and reopen, I get the
following error in console.

Error in event handler for 'undefined': Cannot read property 'length' of
undefined TypeError: Cannot read property 'length' of undefined
at byteArrayToString
(chrome-extension://nedpgficfnmjjgmgcphgfhlknmkgaoij/javascript/passwordmaker/aes.js:292:27)
at
chrome-extension://nedpgficfnmjjgmgcphgfhlknmkgaoij/javascript/settings.js:301:37

This stops the loading of the popup so it is missing the list of
profiles and other things.

I don't understand why it was passing this if statement as true, as the
array element is 'undefined', but this change has fixed it.
