### PR TITLE
Condition invalid, fixed regression

### DIFF
--- a/javascript/settings.js
+++ b/javascript/settings.js
@@ -297,7 +297,7 @@ Settings.getPassword = function(callback) {
         chrome.extension.sendRequest({getPassword: true}, function(response) {
             if (response.password != null && response.password.length > 0) {
                 callback(response.password);
-            } else if (!localStorage["password_crypt"]===undefined) {
+            } else if (localStorage["password_crypt"]!==undefined) {
                 Settings.password = byteArrayToString(rijndaelDecrypt(hexToByteArray(localStorage["password_crypt"]), hexToByteArray(localStorage["password_key"]), "CBC"));
                 callback(Settings.password)
             } else if (localStorage["password"]) {


### PR DESCRIPTION
Fixes password not saving on exit.

Well, really, its password not loading on startup. I checked the
password was being saving inthe SQLITE localstorage, that was fine.
However on load it was not meeting the condition to get the password :(

Don't know how I missed this, I must of reloaded a hundred times prior
to the pull request.
