### PR TITLE
Fixes a bug in content.js when showing the pop up a 2nd time

### DIFF
--- a/javascript/content.js
+++ b/javascript/content.js
@@ -2,14 +2,16 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (request.password) {
         fillPasswords(request.password);
     } else if (request.hasPasswordField) {
-        if (document.querySelector("input[type='password']") !== null) {
+        if (document.querySelector("input[type=password]") !== null) {
             sendResponse({hasField: true});
+        } else {
+            sendResponse({hasField: false});
         }
     }
 });
 
 function fillPasswords(password) {
-    var passFields = document.querySelectorAll("input[type='password']");
+    var passFields = document.querySelectorAll("input[type=password]");
     [].forEach.call(passFields, function (element, index) {
         // Only fill password fields that are empty and aren't already populated (for change password pages)
         if (passFields[index].value.length === 0) {

--- a/javascript/import.js
+++ b/javascript/import.js
@@ -260,5 +260,5 @@ function dumpedProfilesToRdf(profiles) {
 }
 
 function attrEscape(txt){
-    return $('<div/>').text(txt).html().replace(/"/g, "&quot;");
+    return $(document.createElement("div")).text(txt).html().replace(/"/g, "&quot;");
 }

--- a/javascript/settings.js
+++ b/javascript/settings.js
@@ -335,8 +335,7 @@ Settings.clearSyncData = function(callback) {
             Settings.loadLocalProfiles();
             callback(true);
         } else {
-            alert("Could not delete synced data: " + 
-            chrome.runtime.lastError);
+            alert("Could not delete synced data: " + chrome.runtime.lastError);
             callback(false);
         }
     });


### PR DESCRIPTION
Fixes a bug in content.js when showing the pop up a 2nd time on some sites where there isn't a password field (http://www.favbrowser.com/mozilla-ditches-plans-to-display-ads-in-a-new-tab/), the pop up shows the "Fill Field" button anyway.  The chrome run-time system is keeping the response state around somewhere so I'm explicitly returning a "false" message instead of implying a false response.

Also has 2 non-functional style changes.
