### PR TITLE
Add keyboard shortcut for Copy Password

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -350,7 +350,8 @@
                             When you are done typing your master password in the <i>Password</i> textfield of the
                             PassworkMaker Pro popup, you can push <b>Enter</b> to fill the open website'spassword field
                             with the generated password, using the settings that were preselected in the
-                            PasswordMaker Pro popup.<br><br>
+                            PasswordMaker Pro popup.  Alternatively, you can copy the generated password
+                            to the clipboard by pressing <b>Ctrl+C</b>.<br><br>
                             If you do not have the <b>Keep Master Password Hash</b> setting enabled, pushing <b>Enter</b> or
                             <b>Tab</b> in the <i>Password</i> textfield will bring you to the <i>Confirmation</i> textfield. Here you can
                             then push <b>Enter</b>, after you are done typing your master password again, to fill the open

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -141,6 +141,7 @@ function showButtons() {
 }
 
 function fillFields() {
+    updateFields();
     if (!(/^chrome/i).test(Settings.currentUrl)) {
         chrome.tabs.executeScript({
             "allFrames": true,
@@ -170,6 +171,7 @@ function fillFields() {
 }
 
 function copyPassword() {
+    updateFields();
     chrome.tabs.query({ "windowType": "popup" }, function() {
         $("#activatePassword").hide();
         $("#generated").show().get(0).select();
@@ -206,9 +208,12 @@ function enterKeyPressed(event) {
         if ((/password/i).test($("#generated").val())) {
             $("#password").focus();
         } else {
-            updateFields();
             fillFields();
         }
+    }
+    // ctrl+C or option+C: copy password to clipboard
+    if ((event.ctrlKey || event.metaKey) && event.keyCode === 67) {
+	copyPassword();
     }
 }
 


### PR DESCRIPTION
This extends the keyboard handler to recognize Ctrl+C or Option+C
anywhere in the extension popup.  This copies the generated password
to the clipboard the same way the button `Copy Password` does.

Also moved the calls to updateFields, so that this will also be called when
the buttons are pressed.