### PR TITLE
REGEX Compatibility

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
@@ -52,6 +52,15 @@
                 <div class="row">
                     <div class="url_example">
                         <span id="exprotocol">http://</span><span id="exsubdomain">my.</span><span id="exdomain">example.com</span><span id="expath">/my/path?q=search</span>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="subrow">
+                        <label for="siteListType">Match sites using:</label>
+                        <select class="input testInput" id="siteListType">
+                            <option value="wildcard">wildcard patterns</option>
+                            <option value="regex">regular expressions</option>
+                        </select>
                     </div>
                 </div>
                 <div class="row">

--- a/javascript/import.js
+++ b/javascript/import.js
@@ -129,7 +129,9 @@ RdfImporter.loadDoc = function(rdf) {
         var patterns = [],
             patternType = [],
             patternEnabled = [],
-            siteList = "";
+            siteList = "",
+            siteListType = "wildcard";
+
         for (var j = 0; j < this.attributes.length; j++) {
             attrName = this.attributes[j].name.replace(/\w+:/, "");
             var m = attrName.match(/pattern(|type|enabled)(\d+)/);
@@ -145,14 +147,12 @@ RdfImporter.loadDoc = function(rdf) {
         }
         for (var k = 0; k < patterns.length; k++) {
             if (patternEnabled[k] === "true") {
-                if (patternType[k] === "regex") {
-                    siteList += "/" + patterns[k] + "/ ";
-                } else {
-                    siteList += patterns[k] + " ";
-                }
+                siteList += patterns[k] + " ";
+                siteListType = patternType[k];
             }
         }
         prof.siteList = siteList.trim();
+        prof.siteListType = siteListType;
 
         if (prof.rdf_about === "http://passwordmaker.mozdev.org/globalSettings") {
             settings = prof;
@@ -228,9 +228,9 @@ function dumpedProfiles() {
             var pats = prof.siteList.trim().split(/\s+/);
             for (var k = 0; k < pats.length; k++) {
                 var pat = pats[k],
-                    ptype = (pat[0] === "/" && pat[pat.length - 1] === "/") ? "regex" : "wildcard";
+                    ptype = prof.siteListType || ((pat[0] === "/" && pat[pat.length - 1] === "/") ? "regex" : "wildcard");
 
-                newProf["pattern" + k] = (ptype === "regex") ? pat.substring(1, pat.length - 1) : pat;
+                newProf["pattern" + k] = pat.replace(/^\/|\/$/g, '');
                 newProf["patternenabled" + k] = "true";
                 newProf["patterndesc" + k] = "";
                 newProf["patterntype" + k] = ptype;

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -46,6 +46,7 @@ function setCurrentProfile(profile) {
     Settings.currentProfile = profile.id;
     $("#profileNameTB").val(profile.title);
     $("#siteList").val(profile.siteList);
+    $("#siteListType").val(profile.siteListType || "wildcard");
     $("#protocolCB").prop("checked", profile.url_protocol);
     $("#subdomainCB").prop("checked", profile.url_subdomain);
     $("#domainCB").prop("checked", profile.url_domain);
@@ -190,6 +191,7 @@ function saveProfile() {
 
     selected.title          = $("#profileNameTB").val().trim();
     selected.siteList       = $("#siteList").val().trim().split(/\s+/).join(" ");
+    selected.siteListType   = $("#siteListType").val();
     selected.url_protocol   = $("#protocolCB").prop("checked");
     selected.url_subdomain  = $("#subdomainCB").prop("checked");
     selected.url_domain     = $("#domainCB").prop("checked");

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -8,18 +8,22 @@ function getAutoProfileIdForUrl() {
         if (profile.siteList.trim().length !== 0) {
             var sites = profile.siteList.trim().split(/\s+/);
             for (var j = 0; j < sites.length; j++) {
-                var regexString = /\s/;
-                try {
-                    regexString = new RegExp(sites[j], "i");
-                } catch (e) {}
+                var pat = sites[j],
+                    regex = /\s/;
 
-                var plain2regex = sites[j];
-                plain2regex = plain2regex.replace(/[$+()^\[\]\\|{},]/g, "");
-                plain2regex = plain2regex.replace(/\?/g, ".");
-                plain2regex = plain2regex.replace(/\*/g, ".*");
-                var wildcardString = new RegExp(plain2regex, "i");
+                if (pat[0] === "/" && pat[pat.length - 1] === "/") {
+                    regex = new RegExp(pat.substring(1, pat.length - 1), "i");
+                } else if (profile.siteListType && "regex" === profile.siteListType) {
+                    regex = new RegExp(pat, "i");
+                } else {
+                    var plain2regex = pat;
+                    plain2regex = plain2regex.replace(/[$+()^\[\]\\|{},]/g, "");
+                    plain2regex = plain2regex.replace(/\?/g, ".");
+                    plain2regex = plain2regex.replace(/\*/g, ".*");
+                    regex = new RegExp(plain2regex, "i");
+                }
 
-                if (regexString.test(Settings.currentUrl) || wildcardString.test(Settings.currentUrl)) {
+                if (regex.test(Settings.currentUrl)) {
                     return profile.id;
                 }
             }

--- a/test/import.js
+++ b/test/import.js
@@ -38,7 +38,8 @@ QUnit.test("load profile", function(assert) {
     assert.equal(p.passwordSuffix, "suffix1");
     assert.equal(p.whereToUseL33t, "before-hashing");
     assert.equal(p.l33tLevel, 1);
-    assert.equal(p.siteList, "/https?://mail\\.yahoo\\.com/.*/ http?://github.com/*");
+    assert.equal(p.siteList, "https?://mail\\.yahoo\\.com/.* http?://github.com/*");
+    assert.equal(p.siteListType, "wildcard");
 });
 
 QUnit.test("load default profile", function(assert) {
@@ -60,6 +61,7 @@ QUnit.test("load default profile", function(assert) {
     assert.equal(p.whereToUseL33t, "off");
     assert.equal(p.l33tLevel, 1);
     assert.equal(p.siteList, "");
+    assert.equal(p.siteListType, "wildcard");
 });
 
 QUnit.test("save profiles", function(assert) {
@@ -112,7 +114,8 @@ QUnit.test("dump profile to rdf", function(assert) {
     assert.equal(p.passwordSuffix, "suffix1");
     assert.equal(p.whereToUseL33t, "before-hashing");
     assert.equal(p.l33tLevel, 1);
-    assert.equal(p.siteList, "/https?://mail\\.yahoo\\.com/.*/ http?://github.com/*");
+    assert.equal(p.siteList, "https?://mail\\.yahoo\\.com/.* http?://github.com/*");
+    assert.equal(p.siteListType, "wildcard");
 });
 
 QUnit.test("dump default profile to rdf", function(assert) {
@@ -134,6 +137,7 @@ QUnit.test("dump default profile to rdf", function(assert) {
     assert.equal(p.whereToUseL33t, "off");
     assert.equal(p.l33tLevel, 1);
     assert.equal(p.siteList, "");
+    assert.equal(p.siteListType, "wildcard");
 });
 
 QUnit.module("password generation", {


### PR DESCRIPTION
This fixes #165 (regex import/export bug), uses the fix to improve profile matching, and exposes the fix in profiles' options. Technically, only 67f5ea2 is needed to fix #165. The other commits are enhancements that use the fix that you can cherry pick at your discretion, although it'd be nice to see the REGEX option exposed in profile options.