### PR TITLE
Profile Sorting

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
     <head>
         <meta charset="utf-8">
@@ -287,6 +287,12 @@
                 </div>
                 <div class="row">
                     <div class="subrow">
+                        <input id="sortProfiles" type="checkbox">
+                        <label class="checkbox" for="sortProfiles">Sort Profiles</label>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="subrow">
                         <input id="keepMasterPasswordHash" type="checkbox">
                         <label class="checkbox" for="keepMasterPasswordHash">Keep Master Password Hash</label>
                     </div>
@@ -320,7 +326,7 @@
                         <label for="syncProfilesPassword">Master Password</label>
                         <input class="input" id="syncProfilesPassword" type="password">
                     </div>
-                    <div class ="subrow" id="sync_buttons">
+                    <div class="subrow" id="sync_buttons">
                         <button class="button black" id="set_sync_password">Set password</button>
                         <button class="button black" id="clear_sync_data">Delete Sync Data</button>
                     </div>

--- a/javascript/import.js
+++ b/javascript/import.js
@@ -211,6 +211,8 @@ function dumpedProfiles() {
     var dumpProfiles = [],
         expOpts = RdfImporter.getExportOpts();
 
+    Settings.loadLocalProfiles();
+
     for (var i = 0; i < Settings.profiles.length; i++) {
         var prof = Settings.profiles[i],
             newProf = {},
@@ -238,6 +240,9 @@ function dumpedProfiles() {
         }
         dumpProfiles.push(newProf);
     }
+
+    Settings.sortProfiles();
+
     return dumpProfiles;
 }
 

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -246,6 +246,7 @@ function editProfile(event) {
 
 function updateProfileList() {
     $("#profile_list").empty();
+    Settings.sortProfiles();
     for (var i = 0; i < Settings.profiles.length; i++) {
         $("#profile_list").append(`<li><span id='profile_${Settings.profiles[i].id}' class='link'>${Settings.profiles[i].title}</span></li>`);
     }
@@ -351,6 +352,10 @@ function updateHideStoreLocation() {
 
 function updateShowStrength() {
     localStorage.setItem("show_password_strength", $("#showPasswordStrength").prop("checked"));
+}
+
+function updateSortProfiles() {
+    localStorage.setItem("sort_profiles", $("#sortProfiles").prop("checked"));
 }
 
 function sanitizePasswordLength() {
@@ -478,6 +483,7 @@ document.addEventListener("DOMContentLoaded", () => {
     $("#hideStorageLocation").prop("checked", Settings.hideStoreLocationInPopup());
     $("#showPasswordStrength").prop("checked", Settings.shouldShowStrength());
     $("#syncProfiles").prop("checked", Settings.shouldSyncProfiles());
+    $("#sortProfiles").prop("checked", Settings.shouldSortProfiles());
 
     $("#profile_list").on("click", ".link", editProfile);
     $("#add").on("click", addProfile);
@@ -513,6 +519,7 @@ document.addEventListener("DOMContentLoaded", () => {
     $("#useVerificationCode").on("change", updateUseVerificationCode);
     $("#hideStorageLocation").on("change", updateHideStoreLocation);
     $("#showPasswordStrength").on("change", updateShowStrength);
+    $("#sortProfiles").on("change", updateSortProfiles);
     $("#set_sync_password").on("click", setSyncPassword);
     $("#clear_sync_data").on("click", clearSyncData);
     $("#resetToDefaultprofiles").on("click", removeAllProfiles);

--- a/javascript/options.js
+++ b/javascript/options.js
@@ -519,7 +519,11 @@ document.addEventListener("DOMContentLoaded", () => {
     $("#useVerificationCode").on("change", updateUseVerificationCode);
     $("#hideStorageLocation").on("change", updateHideStoreLocation);
     $("#showPasswordStrength").on("change", updateShowStrength);
-    $("#sortProfiles").on("change", updateSortProfiles);
+    $("#sortProfiles").on("change", function () {
+        updateSortProfiles();
+        Settings.loadProfiles();
+        updateProfileList();
+    });
     $("#set_sync_password").on("click", setSyncPassword);
     $("#clear_sync_data").on("click", clearSyncData);
     $("#resetToDefaultprofiles").on("click", removeAllProfiles);

--- a/javascript/popup.js
+++ b/javascript/popup.js
@@ -251,6 +251,7 @@ function init() {
         $("#confirmation").val(pass);
         $("#store_location").val(Settings.storeLocation);
 
+        Settings.sortProfiles();
         for (var i = 0; i < Settings.profiles.length; i++) {
             $("#profile").append(new Option(Settings.profiles[i].title, Settings.profiles[i].id));
         }

--- a/javascript/settings.js
+++ b/javascript/settings.js
@@ -86,6 +86,23 @@ Settings.loadProfiles = () => {
     }
 };
 
+Settings.sortProfiles = () => {
+    if (!Settings.shouldSortProfiles()) { return; }
+
+    var profiles = Settings.profiles,
+        defaultProfile = profiles.shift();
+
+    profiles.sort(function (a, b) {
+        if (a.title.toLowerCase() < b.title.toLowerCase()) { return -1; }
+        if (a.title.toLowerCase() > b.title.toLowerCase()) { return 1; }
+        return 0;
+    });
+
+    profiles.unshift(defaultProfile);
+
+    Settings.profiles = profiles;
+};
+
 Settings.saveSyncedProfiles = data => {
     var oldKeys = localStorage.getItem("synced_profiles_keys");
     var threshold = Math.round(chrome.storage.sync.QUOTA_BYTES_PER_ITEM * 0.9);
@@ -217,6 +234,10 @@ Settings.useVerificationCode = () => {
 
 Settings.shouldShowStrength = () => {
     return localStorage.getItem("show_password_strength") === "true";
+};
+
+Settings.shouldSortProfiles = () => {
+    return localStorage.getItem("sort_profiles") === "true";
 };
 
 Settings.stopSync = () => {


### PR DESCRIPTION
Adds sorting to address half of #167. I'll discuss the other half, grouping, in that issue.

I implemented this using a cosmetic-only approach that sorts the profiles when displayed without updating their order in localStorage. While this is less efficient than sorting once and storing sorted, it gives the user a reversible option and allows order to be maintained during export. A use case for why this might be important is if the user manually ordered the RDF, tried and decided against sorted, and wanted to return to their manual sort.